### PR TITLE
change warn->warning

### DIFF
--- a/src/subprocess_middleware/worker.py
+++ b/src/subprocess_middleware/worker.py
@@ -121,7 +121,7 @@ class TransformWorker(object):
             except ValueError as e:
                 errout = self.clear_process(process)
                 if attempt == 1:
-                    log.warn('Retrying: %r\n%s', e, errout)
+                    log.warning('Retrying: %r\n%s', e, errout)
                     continue
                 raise
 


### PR DESCRIPTION
this was triggering an error on retry in circle-ci after we cleaning up warnings.